### PR TITLE
feat(mobile): モバイル用キューパネルのオーバーレイ表示機能を実装

### DIFF
--- a/components/PlayerQueuePanel.vue
+++ b/components/PlayerQueuePanel.vue
@@ -2,6 +2,9 @@
   import { usePlayerQueue } from "~/stores/usePlayerQueue";
 
   const playerQueue = usePlayerQueue();
+
+  // Emits（モバイル用の閉じる機能）
+  const emit = defineEmits(["close"]);
 </script>
 
 <template>
@@ -10,7 +13,29 @@
   >
     <!-- ヘッダー -->
     <div class="flex-shrink-0 p-4 border-b border-gray-200 bg-white">
-      <h2 class="text-lg font-bold text-gray-800">再生キュー</h2>
+      <div class="flex items-center justify-between">
+        <h2 class="text-lg font-bold text-gray-800">再生キュー</h2>
+        <!-- モバイル用閉じるボタン -->
+        <button
+          class="lg:hidden p-1 text-gray-500 hover:text-gray-700 rounded-full hover:bg-gray-100"
+          title="閉じる"
+          @click="emit('close')"
+        >
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
 
     <!-- スクロール可能なコンテンツエリア -->
@@ -175,6 +200,17 @@
 
     .queue-content {
       padding-bottom: calc(var(--player-height-desktop) + 120px) !important;
+    }
+  }
+
+  /* モバイルオーバーレイ時の調整 */
+  @media (max-width: 1023px) {
+    .queue-content {
+      padding-bottom: calc(var(--player-height-mobile) + 120px);
+    }
+
+    .queue-footer {
+      bottom: var(--player-height-mobile);
     }
   }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -66,6 +66,41 @@
       </button>
     </div>
 
+    <!-- モバイル用キューパネルオーバーレイ -->
+    <Transition
+      enter-active-class="transition-all duration-300 ease-out"
+      leave-active-class="transition-all duration-300 ease-in"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="isQueuePanelOpen" class="lg:hidden fixed inset-0 z-50">
+        <!-- オーバーレイ背景 -->
+        <div
+          class="absolute inset-0 bg-gradient-to-r from-black/40 to-black/20"
+          @click="toggleQueue"
+        />
+
+        <!-- キューパネル -->
+        <Transition
+          enter-active-class="transition-transform duration-300 ease-out"
+          leave-active-class="transition-transform duration-300 ease-in"
+          enter-from-class="translate-x-full"
+          enter-to-class="translate-x-0"
+          leave-from-class="translate-x-0"
+          leave-to-class="translate-x-full"
+        >
+          <div
+            v-if="isQueuePanelOpen"
+            class="absolute right-0 top-0 h-full w-80 bg-white shadow-xl"
+          >
+            <PlayerQueuePanel @close="toggleQueue" />
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+
     <!-- フッター（固定） -->
     <div class="flex-shrink-0">
       <LayoutFooter />


### PR DESCRIPTION
- モバイルでキューパネルをオーバーレイ表示する機能を追加
- 半透明グラデーション背景で視認性を向上
- フェードイン/アウトとスライドアニメーションを実装
- 背景タップまたは閉じるボタンでパネルを閉じる機能
- PlayerQueuePanelに閉じるボタンとemit機能を追加

Changes:
- layouts/default.vue: モバイル用オーバーレイとアニメーション追加
- components/PlayerQueuePanel.vue: モバイル用閉じるボタンとemit追加