### PR TITLE
feat: Google Analytics 4 (GA4) による利用状況の計測機能を実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
 # Django REST API Configuration
 DJANGO_API_URL=http://127.0.0.1:8000/api
+
+# Google Analytics 4 Configuration
+# GA4測定IDを設定してください (例: G-XXXXXXXXXX)
+# Google Analytics管理画面で取得できます
+NUXT_PUBLIC_GA_ID=
+
+# Site URL (本番環境のURL)
+NUXT_PUBLIC_SITE_URL=https://inuinouta-front-v3.vercel.app

--- a/components/PlaylistCreateModal.vue
+++ b/components/PlaylistCreateModal.vue
@@ -12,6 +12,7 @@
 
   const { createPlaylist, loading } = useLocalPlaylist();
   const toast = useToast();
+  const analytics = useAnalytics();
 
   // フォームデータ
   const name = ref("");
@@ -55,6 +56,9 @@
         name: name.value.trim(),
         description: description.value.trim() || undefined,
       });
+
+      // アナリティクス: プレイリスト作成を追跡
+      analytics.trackPlaylistAction('create', playlist.id, undefined);
 
       toast.success(`プレイリスト「${playlist.name}」を作成しました`);
       emit("created", playlist);

--- a/components/PlaylistEditModal.vue
+++ b/components/PlaylistEditModal.vue
@@ -13,6 +13,7 @@
 
   const { updatePlaylist, loading } = useLocalPlaylist();
   const toast = useToast();
+  const analytics = useAnalytics();
 
   // フォームデータ
   const name = ref("");
@@ -66,6 +67,9 @@
         name: name.value.trim(),
         description: description.value.trim() || undefined,
       });
+
+      // アナリティクス: プレイリスト編集を追跡
+      analytics.trackPlaylistAction("edit", updatedPlaylist.id, undefined);
 
       toast.success("プレイリストを更新しました");
       emit("updated", updatedPlaylist);

--- a/components/SiteInfoModal.vue
+++ b/components/SiteInfoModal.vue
@@ -96,7 +96,10 @@
             </h3>
             <ul class="text-sm space-y-2 list-disc list-inside">
               <li>楽曲・歌枠配信の検索と視聴</li>
-              <li>連続再生機能</li>
+              <li>アーティスト、楽曲タイプ、動画タイプでのフィルタリング</li>
+              <li>お気に入りプレイリストの作成・管理</li>
+              <li>連続再生機能（キュー管理）</li>
+              <li>ランダム歌枠再生</li>
             </ul>
           </section>
 
@@ -194,6 +197,34 @@
                   wavebox.me/wave/4v3755rdt2e2otd5
                 </a>
               </div>
+            </div>
+          </section>
+
+          <!-- プライバシー・アナリティクス -->
+          <section>
+            <h3
+              class="text-lg font-semibold text-white mb-3 flex items-center gap-2"
+            >
+              <span>📊</span>
+              <span>アクセス解析について</span>
+            </h3>
+            <div class="text-sm leading-relaxed space-y-3">
+              <p>
+                当サイトでは、サービス改善のためGoogle Analytics
+                4を使用してアクセス解析を行っています。
+              </p>
+              <p class="text-gray-400">
+                収集される情報には、ページビュー、楽曲の再生・検索履歴、プレイリスト操作などの統計データが含まれます。これらの情報は個人を特定するものではなく、サイトの機能改善や利用傾向の把握のみに使用されます。
+              </p>
+              <p class="text-gray-400">
+                詳しくは<a
+                  href="https://policies.google.com/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-400 hover:text-blue-300 transition-colors"
+                  >Googleプライバシーポリシー</a
+                >をご確認ください。
+              </p>
             </div>
           </section>
 

--- a/components/SongRow.vue
+++ b/components/SongRow.vue
@@ -245,7 +245,7 @@
           :href="youtubeUrl"
           target="_blank"
           rel="noopener noreferrer"
-          @click="closeMenu"
+          @click="handleYouTubeClick"
           :class="SONG_ROW_STYLES.contextMenu.menuItem"
         >
           <svg
@@ -293,6 +293,7 @@
   // Stores
   const queue = usePlayerQueue();
   const player = usePlayerStore();
+  const analytics = useAnalytics();
 
   // Emits（外部との互換性を保持）
   const emit = defineEmits(["play-now", "add-to-queue", "add-to-playlist"]);
@@ -417,6 +418,9 @@
 
   // 直接再生（前プロジェクトのclickSongを参考）
   const playNow = () => {
+    // アナリティクス: 楽曲再生を追跡
+    analytics.trackSongPlay(props.song);
+
     // ユーザーインタラクション記録（モバイル対応強化）
     player.setUserInteracted(true);
 
@@ -442,6 +446,10 @@
   // キューに追加
   const addToQueue = () => {
     console.log("Adding to queue:", props.song.title);
+
+    // アナリティクス: キューに追加を追跡
+    analytics.trackAddToQueue(props.song);
+
     queue.addToQueue(props.song);
     emit("add-to-queue", props.song);
   };
@@ -455,8 +463,21 @@
   // プレイリスト追加完了ハンドラ
   const handlePlaylistAdded = (playlistId) => {
     console.log("Song added to playlist:", playlistId);
+
+    // アナリティクス: プレイリストに追加を追跡
+    analytics.trackPlaylistAction("add_song", playlistId, props.song.id);
+
     showAddToPlaylistModal.value = false;
     emit("add-to-playlist", { song: props.song, playlistId });
+  };
+
+  // YouTubeリンククリックハンドラ
+  const handleYouTubeClick = () => {
+    // アナリティクス: YouTubeリンククリックを追跡
+    if (props.song.video) {
+      analytics.trackYouTubeClick(props.song.id, props.song.video.id);
+    }
+    closeMenu();
   };
 
   // 現在再生中の楽曲かどうか（シンプルな判定）

--- a/composables/useAnalytics.ts
+++ b/composables/useAnalytics.ts
@@ -1,0 +1,136 @@
+import type { Song } from "~/types/song";
+
+/**
+ * Google Analytics イベント追跡用のComposable
+ *
+ * 使用例:
+ * const analytics = useAnalytics()
+ * analytics.trackSongPlay(song)
+ */
+export const useAnalytics = () => {
+  const { $gtag } = useNuxtApp();
+
+  /**
+   * イベントを送信する内部メソッド
+   */
+  const sendEvent = (eventName: string, eventParams?: Record<string, any>) => {
+    if (typeof $gtag === "function") {
+      $gtag("event", eventName, eventParams);
+    } else {
+      // 開発環境などでGA4が無効な場合はコンソールに出力
+      console.log("Analytics Event:", eventName, eventParams);
+    }
+  };
+
+  /**
+   * ページビューを手動で送信
+   * (通常はプラグインが自動で送信するため、SPAの特殊なケースのみ使用)
+   */
+  const trackPageView = (pagePath: string, pageTitle?: string) => {
+    sendEvent("page_view", {
+      page_path: pagePath,
+      page_title: pageTitle || document.title,
+    });
+  };
+
+  /**
+   * 楽曲再生イベントを追跡
+   */
+  const trackSongPlay = (song: Song) => {
+    sendEvent("play_song", {
+      song_id: song.id,
+      song_title: song.title,
+      artist: song.artist,
+      is_original: song.is_original,
+      has_video: !!song.video,
+      is_stream: song.video?.is_stream || false,
+    });
+  };
+
+  /**
+   * 楽曲をキューに追加したイベントを追跡
+   */
+  const trackAddToQueue = (song: Song) => {
+    sendEvent("add_to_queue", {
+      song_id: song.id,
+      song_title: song.title,
+      artist: song.artist,
+    });
+  };
+
+  /**
+   * 検索イベントを追跡
+   */
+  const trackSearch = (query: string, resultCount?: number) => {
+    sendEvent("search", {
+      search_term: query,
+      result_count: resultCount,
+    });
+  };
+
+  /**
+   * プレイリスト操作イベントを追跡
+   */
+  const trackPlaylistAction = (
+    action: "create" | "edit" | "delete" | "play" | "add_song",
+    playlistId?: string,
+    songId?: number
+  ) => {
+    sendEvent("playlist_action", {
+      action,
+      playlist_id: playlistId,
+      song_id: songId,
+    });
+  };
+
+  /**
+   * YouTubeリンククリックを追跡
+   */
+  const trackYouTubeClick = (songId: number, videoId: string) => {
+    sendEvent("youtube_click", {
+      song_id: songId,
+      video_id: videoId,
+    });
+  };
+
+  /**
+   * パーマリンクコピーを追跡
+   */
+  const trackPermalinkCopy = (songId: number) => {
+    sendEvent("permalink_copy", {
+      song_id: songId,
+    });
+  };
+
+  /**
+   * ソート変更を追跡
+   */
+  const trackSortChange = (sortBy: string, order: string) => {
+    sendEvent("sort_change", {
+      sort_by: sortBy,
+      order: order,
+    });
+  };
+
+  /**
+   * フィルター適用を追跡
+   */
+  const trackFilterApply = (filterType: string, filterValue: any) => {
+    sendEvent("filter_apply", {
+      filter_type: filterType,
+      filter_value: filterValue,
+    });
+  };
+
+  return {
+    trackPageView,
+    trackSongPlay,
+    trackAddToQueue,
+    trackSearch,
+    trackPlaylistAction,
+    trackYouTubeClick,
+    trackPermalinkCopy,
+    trackSortChange,
+    trackFilterApply,
+  };
+};

--- a/docs/ANALYTICS_IMPLEMENTATION.md
+++ b/docs/ANALYTICS_IMPLEMENTATION.md
@@ -1,0 +1,301 @@
+# アナリティクス実装概要
+
+Google Analytics 4 (GA4) を使用したユーザーアクティビティ計測の実装が完了しました。
+
+## 📊 実装済みの計測ポイント
+
+### 1. 楽曲再生 (`play_song`)
+
+**追跡内容**: ユーザーがどの楽曲をどこから再生したか
+
+**実装箇所**:
+
+- ✅ `pages/songs/[id].vue` - 楽曲詳細ページの「今すぐ再生」ボタン
+- ✅ `components/SongRow.vue` - 楽曲リストのサムネイル/タイトルクリック
+- ✅ `pages/playlists/[id].vue` - プレイリスト内の楽曲クリック
+
+**パラメータ**:
+
+```typescript
+{
+  song_id: number,
+  song_title: string,
+  artist: string,
+  is_original: boolean,
+  has_video: boolean,
+  is_stream: boolean
+}
+```
+
+### 2. キューに追加 (`add_to_queue`)
+
+**追跡内容**: ユーザーがどの楽曲をキューに追加したか
+
+**実装箇所**:
+
+- ✅ `pages/songs/[id].vue` - 楽曲詳細ページの「キューに追加」ボタン
+- ✅ `components/SongRow.vue` - コンテキストメニューの「キューに追加」
+- ✅ `pages/playlists/[id].vue` - プレイリスト内のキュー追加
+
+**パラメータ**:
+
+```typescript
+{
+  song_id: number,
+  song_title: string,
+  artist: string
+}
+```
+
+### 3. 検索 (`search`)
+
+**追跡内容**: ユーザーがどのキーワードで検索したか、結果数
+
+**実装箇所**:
+
+- ✅ `pages/songs/index.vue` - 楽曲検索（1 秒デバウンス付き）
+- ✅ `pages/streams/index.vue` - 歌枠検索（1 秒デバウンス付き）
+
+**パラメータ**:
+
+```typescript
+{
+  search_term: string,
+  result_count: number
+}
+```
+
+**特徴**: デバウンス処理により、ユーザーが入力を続けている間は送信されず、1 秒間入力が止まった時点で送信されます。
+
+### 4. フィルター適用 (`filter_apply`)
+
+**追跡内容**: ユーザーがどのフィルターを使用したか
+
+**実装箇所**:
+
+- ✅ `pages/songs/index.vue` - アーティスト、楽曲タイプ、動画タイプフィルター
+
+**パラメータ**:
+
+```typescript
+{
+  filter_type: 'artist' | 'song_type' | 'video_type',
+  filter_value: string
+}
+```
+
+### 5. ソート変更 (`sort_change`)
+
+**追跡内容**: ユーザーがどのソート条件を選択したか
+
+**実装箇所**:
+
+- ✅ `pages/songs/index.vue` - 楽曲一覧のソート変更
+- ✅ `pages/streams/index.vue` - 歌枠一覧のソート変更
+
+**パラメータ**:
+
+```typescript
+{
+  sort_by: 'songs' | 'streams',
+  order: string // 例: '-video.published_at,start_at'
+}
+```
+
+### 6. プレイリスト操作 (`playlist_action`)
+
+**追跡内容**: プレイリストの作成、編集、削除、再生
+
+**実装箇所**:
+
+- ✅ `components/PlaylistCreateModal.vue` - プレイリスト作成
+- ✅ `components/PlaylistEditModal.vue` - プレイリスト編集
+- ✅ `pages/playlists/[id].vue` - プレイリスト削除、全曲再生
+- ✅ `components/SongRow.vue` - プレイリストに楽曲追加
+- ✅ `pages/streams/index.vue` - 歌枠全体をキューに追加、ランダム再生
+
+**パラメータ**:
+
+```typescript
+{
+  action: 'create' | 'edit' | 'delete' | 'play' | 'add_song',
+  playlist_id?: string,
+  song_id?: number
+}
+```
+
+### 7. YouTube リンククリック (`youtube_click`)
+
+**追跡内容**: ユーザーが YouTube リンクをクリックした
+
+**実装箇所**:
+
+- ✅ `pages/songs/[id].vue` - 楽曲詳細ページの「YouTube で開く」ボタン
+- ✅ `components/SongRow.vue` - コンテキストメニューの「YouTube で開く」
+
+**パラメータ**:
+
+```typescript
+{
+  song_id: number,
+  video_id: string
+}
+```
+
+### 8. パーマリンクコピー (`permalink_copy`)
+
+**追跡内容**: ユーザーが楽曲のパーマリンクをコピーした
+
+**実装箇所**:
+
+- ✅ `pages/songs/[id].vue` - 楽曲詳細ページの「コピー」ボタン
+
+**パラメータ**:
+
+```typescript
+{
+  song_id: number;
+}
+```
+
+### 9. ページビュー (`page_view`)
+
+**追跡内容**: ページ遷移（自動）
+
+**実装箇所**:
+
+- ✅ `plugins/gtag.client.ts` - ルート変更時に自動送信
+
+**パラメータ**:
+
+```typescript
+{
+  page_path: string,
+  page_title: string,
+  page_location: string
+}
+```
+
+## 🛠️ 技術仕様
+
+### アーキテクチャ
+
+```
+plugins/gtag.client.ts
+├── Google Analytics スクリプト読み込み
+├── gtag 関数の初期化
+└── ページビューの自動トラッキング
+
+composables/useAnalytics.ts
+├── カスタムイベント送信のラッパー
+├── 各種トラッキングメソッド
+└── 開発環境対応（コンソール出力）
+
+各ページ・コンポーネント
+├── useAnalytics() の呼び出し
+└── 適切なタイミングでイベント送信
+```
+
+### デバウンス処理
+
+検索イベントには 1 秒のデバウンスが実装されています：
+
+```typescript
+let searchDebounceTimer: NodeJS.Timeout | null = null;
+watch(searchQuery, (newQuery) => {
+  if (searchDebounceTimer) {
+    clearTimeout(searchDebounceTimer);
+  }
+
+  if (newQuery.trim()) {
+    searchDebounceTimer = setTimeout(() => {
+      analytics.trackSearch(newQuery, filteredResults.value.length);
+    }, 1000);
+  }
+});
+```
+
+これにより、ユーザーが入力中に過度なイベント送信を防ぎます。
+
+## 📈 分析可能なインサイト
+
+実装された計測により、以下のような分析が可能になります：
+
+### ユーザー行動分析
+
+- 最も再生される楽曲・アーティスト
+- プレイリスト作成・編集の頻度
+- 検索キーワードの傾向
+
+### コンテンツ人気度
+
+- オリジナル曲 vs カバー曲の人気
+- 歌動画 vs 配信アーカイブの人気
+- アーティスト別の再生数
+
+### 機能利用状況
+
+- キュー機能の使用頻度
+- プレイリスト機能の利用状況
+- フィルター・ソート機能の利用パターン
+
+### ユーザーフロー
+
+- 楽曲詳細ページへの遷移元
+- プレイリストからの再生率
+- YouTube への外部遷移率
+
+## 🎯 今後の拡張可能性
+
+### 追加で計測できる項目
+
+1. **再生時間の計測**
+
+   - 楽曲をどれだけの時間聴いたか
+   - スキップ率の計測
+
+2. **エラートラッキング**
+
+   - 再生エラーの発生状況
+   - API エラーの記録
+
+3. **パフォーマンス計測**
+
+   - ページ読み込み時間
+   - API レスポンス時間
+
+4. **カスタムディメンション**
+   - ユーザーセグメント（新規/リピーター）
+   - デバイスタイプ別分析
+
+## 📝 メンテナンス
+
+### イベント追加方法
+
+新しいイベントを追加する場合：
+
+1. `composables/useAnalytics.ts` に新しいメソッドを追加
+2. 該当するページ・コンポーネントで `useAnalytics()` を呼び出し
+3. 適切なタイミングでメソッドを実行
+4. このドキュメントを更新
+
+### デバッグ方法
+
+開発環境では、イベントはコンソールに出力されます：
+
+```
+Analytics Event: play_song {song_id: 123, song_title: "...", ...}
+```
+
+本番環境では、Google Analytics のリアルタイムレポートで確認できます。
+
+## 🔒 プライバシーへの配慮
+
+- 個人を特定できる情報（PII）は送信していません
+- 楽曲 ID、タイトル、アーティスト名など公開情報のみ
+- Cookie 同意バナーの実装を推奨（今後の課題）
+
+## 📚 関連ドキュメント
+
+- [GA4_SETUP.md](./GA4_SETUP.md) - セットアップ手順
+- [Google Analytics 4 公式ドキュメント](https://support.google.com/analytics/answer/9304153)

--- a/docs/GA4_SETUP.md
+++ b/docs/GA4_SETUP.md
@@ -1,0 +1,200 @@
+# Google Analytics 4 (GA4) セットアップガイド
+
+このプロジェクトには Google Analytics 4 (GA4)が統合されており、ユーザーのアクティビティを計測できます。
+
+## セットアップ手順
+
+### 1. Google Analytics 4 アカウントの作成
+
+1. [Google Analytics](https://analytics.google.com/)にアクセス
+2. 「測定を開始」をクリック
+3. アカウントを作成
+4. プロパティを作成（プラットフォーム: ウェブ）
+5. **測定 ID（G-XXXXXXXXXX 形式）**を取得
+
+### 2. 環境変数の設定
+
+プロジェクトルートに `.env` ファイルを作成し、取得した測定 ID を設定します。
+
+```bash
+# .env ファイルを作成
+cp .env.example .env
+```
+
+`.env` ファイルを編集：
+
+```bash
+# Google Analytics 4 測定ID
+NUXT_PUBLIC_GA_ID=G-XXXXXXXXXX  # ←ここに取得した測定IDを入力
+```
+
+### 3. 本番環境（Vercel）での設定
+
+Vercel にデプロイしている場合：
+
+1. Vercel のプロジェクトダッシュボードにアクセス
+2. Settings → Environment Variables
+3. 以下の環境変数を追加：
+   - Key: `NUXT_PUBLIC_GA_ID`
+   - Value: `G-XXXXXXXXXX`（取得した測定 ID）
+   - Environment: Production, Preview, Development (必要に応じて)
+
+### 4. 動作確認
+
+開発サーバーを起動：
+
+```bash
+pnpm dev
+```
+
+ブラウザの開発者ツール（Console）で以下を確認：
+
+- GA4 スクリプトが読み込まれている
+- イベントが送信されている（`Analytics Event:` のログ）
+
+Google Analytics の**リアルタイムレポート**でもデータが表示されることを確認できます。
+
+## 計測されるイベント
+
+### 自動計測
+
+- **ページビュー**: ページ遷移時に自動送信
+
+### カスタムイベント
+
+以下のユーザーアクションを計測しています：
+
+#### 楽曲関連
+
+- `play_song`: 楽曲を再生
+
+  - `song_id`, `song_title`, `artist`, `is_original`, `has_video`, `is_stream`
+  - **実装箇所**:
+    - `pages/songs/[id].vue` - 楽曲詳細ページでの再生
+    - `components/SongRow.vue` - 楽曲リスト内での再生
+    - `pages/playlists/[id].vue` - プレイリストからの再生
+
+- `add_to_queue`: 楽曲をキューに追加
+  - `song_id`, `song_title`, `artist`
+  - **実装箇所**:
+    - `pages/songs/[id].vue` - 楽曲詳細ページ
+    - `components/SongRow.vue` - 楽曲リスト
+    - `pages/playlists/[id].vue` - プレイリスト詳細
+
+#### リンク・コピー
+
+- `youtube_click`: YouTube リンクをクリック
+
+  - `song_id`, `video_id`
+  - **実装箇所**:
+    - `pages/songs/[id].vue` - 楽曲詳細ページ
+    - `components/SongRow.vue` - 楽曲リストのコンテキストメニュー
+
+- `permalink_copy`: パーマリンクをコピー
+  - `song_id`
+  - **実装箇所**:
+    - `pages/songs/[id].vue` - 楽曲詳細ページ
+
+#### 検索・フィルター
+
+- `search`: 検索を実行
+
+  - `search_term`, `result_count`
+  - **実装箇所**:
+    - `pages/songs/index.vue` - 楽曲一覧ページ（デバウンス付き）
+    - `pages/streams/index.vue` - 歌枠一覧ページ（デバウンス付き）
+
+- `sort_change`: ソート条件を変更
+
+  - `sort_by`, `order`
+  - **実装箇所**:
+    - `pages/songs/index.vue` - 楽曲一覧ページ
+    - `pages/streams/index.vue` - 歌枠一覧ページ
+
+- `filter_apply`: フィルターを適用
+  - `filter_type`, `filter_value`
+  - **実装箇所**:
+    - `pages/songs/index.vue` - アーティスト、楽曲タイプ、動画タイプフィルター
+
+#### プレイリスト
+
+- `playlist_action`: プレイリスト操作
+  - `action` (`create`, `edit`, `delete`, `play`, `add_song`)
+  - `playlist_id`, `song_id`
+  - **実装箇所**:
+    - `components/PlaylistCreateModal.vue` - プレイリスト作成
+    - `components/PlaylistEditModal.vue` - プレイリスト編集
+    - `pages/playlists/[id].vue` - プレイリスト削除、全曲再生、楽曲再生
+    - `components/SongRow.vue` - プレイリストに楽曲追加
+    - `pages/streams/index.vue` - 歌枠全体をキューに追加、ランダム歌枠再生
+
+## 使い方
+
+### ページにイベントトラッキングを追加する
+
+```vue
+<script setup>
+  const analytics = useAnalytics();
+
+  // 楽曲再生をトラッキング
+  const handlePlay = (song) => {
+    analytics.trackSongPlay(song);
+    // ... 実際の再生処理
+  };
+
+  // 検索をトラッキング
+  const handleSearch = (query, results) => {
+    analytics.trackSearch(query, results.length);
+    // ... 検索処理
+  };
+</script>
+```
+
+### 利用可能なメソッド
+
+`useAnalytics()` composable で以下のメソッドが使えます：
+
+- `trackPageView(pagePath, pageTitle?)` - ページビュー
+- `trackSongPlay(song)` - 楽曲再生
+- `trackAddToQueue(song)` - キューに追加
+- `trackSearch(query, resultCount?)` - 検索
+- `trackPlaylistAction(action, playlistId?, songId?)` - プレイリスト操作
+- `trackYouTubeClick(songId, videoId)` - YouTube リンククリック
+- `trackPermalinkCopy(songId)` - パーマリンクコピー
+- `trackSortChange(sortBy, order)` - ソート変更
+- `trackFilterApply(filterType, filterValue)` - フィルター適用
+
+## トラブルシューティング
+
+### イベントが送信されない
+
+1. 環境変数 `NUXT_PUBLIC_GA_ID` が正しく設定されているか確認
+2. ブラウザの開発者ツールでコンソールエラーを確認
+3. 広告ブロッカーが有効になっていないか確認
+
+### リアルタイムレポートにデータが表示されない
+
+- データの反映には数分かかる場合があります
+- 測定 ID が正しいか確認
+- ブラウザのプライベートモードで試してみる
+
+### 開発環境で GA4 を無効にしたい
+
+環境変数を設定しない、または空文字列にすると、イベントはコンソールにのみ出力されます。
+
+```bash
+# .env
+NUXT_PUBLIC_GA_ID=  # 空にする
+```
+
+## プライバシーへの配慮
+
+- 個人を特定できる情報（PII）は送信しないようにしてください
+- 必要に応じてプライバシーポリシーを更新してください
+- Cookie 同意バナーの実装を検討してください
+
+## 参考リンク
+
+- [Google Analytics 4 公式ドキュメント](https://support.google.com/analytics/answer/9304153)
+- [gtag.js リファレンス](https://developers.google.com/analytics/devguides/collection/gtagjs)
+- [Nuxt 3 ドキュメント](https://nuxt.com/docs)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,6 +18,7 @@ export default defineNuxtConfig({
       siteUrl:
         process.env.NUXT_PUBLIC_SITE_URL ||
         "https://inuinouta-front-v3.vercel.app",
+      gaId: process.env.NUXT_PUBLIC_GA_ID || "", // Google Analytics 測定ID (G-XXXXXXXXXX)
     },
   },
   vite: {

--- a/pages/playlists/[id].vue
+++ b/pages/playlists/[id].vue
@@ -24,6 +24,7 @@
   const playerStore = usePlayerStore();
   const queueStore = usePlayerQueue();
   const toast = useToast();
+  const analytics = useAnalytics();
 
   // プレイリストIDを取得
   const playlistId = route.params.id as string;
@@ -92,6 +93,10 @@
 
   // 楽曲をクリックしたときの処理（今すぐ再生）
   const handlePlaySong = (song: Song) => {
+    // アナリティクス: プレイリストから楽曲再生を追跡
+    analytics.trackSongPlay(song);
+    analytics.trackPlaylistAction("play", playlistId, song.id);
+
     // ユーザーインタラクション記録
     playerStore.setUserInteracted(true);
 
@@ -110,6 +115,9 @@
 
   // キューに追加
   const handleAddToQueue = (song: Song) => {
+    // アナリティクス: キューに追加を追跡
+    analytics.trackAddToQueue(song);
+
     queueStore.addToQueue(song);
   };
 
@@ -143,6 +151,9 @@
     if (songs.value.length === 0) {
       return;
     }
+
+    // アナリティクス: プレイリスト全曲再生を追跡
+    analytics.trackPlaylistAction("play", playlistId, undefined);
 
     // ユーザーインタラクション記録
     playerStore.setUserInteracted(true);
@@ -180,6 +191,10 @@
     if (confirm(`「${playlist.value.name}」を削除しますか？`)) {
       try {
         await deletePlaylist(playlistId);
+
+        // アナリティクス: プレイリスト削除を追跡
+        analytics.trackPlaylistAction("delete", playlistId, undefined);
+
         toast.success("プレイリストを削除しました");
         router.push("/playlists");
       } catch (e) {

--- a/pages/songs/[id].vue
+++ b/pages/songs/[id].vue
@@ -155,6 +155,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium flex items-center justify-center gap-2 whitespace-nowrap"
+                @click="handleYouTubeClick"
               >
                 <svg
                   class="w-5 h-5"
@@ -275,6 +276,7 @@
 
   const queue = usePlayerQueue();
   const player = usePlayerStore();
+  const analytics = useAnalytics();
   const copied = ref(false);
 
   // 戻るボタンの処理
@@ -409,6 +411,9 @@
   const playNow = async () => {
     if (!song.value) return;
 
+    // アナリティクス: 楽曲再生を追跡
+    analytics.trackSongPlay(song.value);
+
     player.setUserInteracted(true);
     queue.setQueue([song.value]);
     queue.play(0);
@@ -430,9 +435,20 @@
 
   const addToQueue = () => {
     if (!song.value) return;
+
+    // アナリティクス: キューに追加を追跡
+    analytics.trackAddToQueue(song.value);
+
     queue.addToQueue(song.value);
     // TODO: トースト通知などでユーザーにフィードバックを提供
     console.log("キューに追加しました:", song.value.title);
+  };
+
+  const handleYouTubeClick = () => {
+    // アナリティクス: YouTubeリンククリックを追跡
+    if (song.value?.video) {
+      analytics.trackYouTubeClick(song.value.id, song.value.video.id);
+    }
   };
 
   const selectPermalink = (event: Event) => {
@@ -446,6 +462,12 @@
     try {
       await navigator.clipboard.writeText(permalink.value);
       copied.value = true;
+
+      // アナリティクス: パーマリンクコピーを追跡
+      if (song.value) {
+        analytics.trackPermalinkCopy(song.value.id);
+      }
+
       setTimeout(() => {
         copied.value = false;
       }, 2000);
@@ -460,6 +482,12 @@
           input.select();
           document.execCommand("copy");
           copied.value = true;
+
+          // アナリティクス: パーマリンクコピーを追跡
+          if (song.value) {
+            analytics.trackPermalinkCopy(song.value.id);
+          }
+
           setTimeout(() => {
             copied.value = false;
           }, 2000);

--- a/plugins/gtag.client.ts
+++ b/plugins/gtag.client.ts
@@ -1,0 +1,61 @@
+/**
+ * Google Analytics 4 (GA4) プラグイン
+ * クライアントサイドのみで動作します
+ */
+
+// Window型の拡張
+declare global {
+  interface Window {
+    dataLayer: any[];
+    gtag: (...args: any[]) => void;
+  }
+}
+
+export default defineNuxtPlugin(() => {
+  const config = useRuntimeConfig();
+  const router = useRouter();
+
+  // GA4 測定IDが設定されていない場合は何もしない
+  if (!config.public.gaId) {
+    console.warn("GA4 測定IDが設定されていません");
+    return;
+  }
+
+  // Google Analytics スクリプトを読み込み
+  useHead({
+    script: [
+      {
+        src: `https://www.googletagmanager.com/gtag/js?id=${config.public.gaId}`,
+        async: true,
+      },
+    ],
+  });
+
+  // gtag を初期化
+  window.dataLayer = window.dataLayer || [];
+  function gtag(...args: any[]) {
+    window.dataLayer.push(args);
+  }
+  window.gtag = gtag;
+
+  gtag("js", new Date());
+  gtag("config", config.public.gaId, {
+    send_page_view: false, // 手動でページビューを送信するため無効化
+  });
+
+  // ルート変更時に自動的にページビューを送信
+  router.afterEach((to) => {
+    gtag("event", "page_view", {
+      page_path: to.fullPath,
+      page_title: document.title,
+      page_location: window.location.href,
+    });
+  });
+
+  // gtagをグローバルに提供
+  return {
+    provide: {
+      gtag,
+    },
+  };
+});


### PR DESCRIPTION
- Google Analytics 4 プラグイン (gtag.client.ts) を追加
- useAnalytics composable で各種イベントトラッキング機能を実装
- ページビューの自動トラッキング
- 楽曲再生、キュー追加、検索、フィルター、ソート変更のトラッキング
- プレイリスト操作（作成、編集、削除、再生）のトラッキング
- YouTubeリンククリック、パーマリンクコピーのトラッキング
- 検索イベントは1秒のデバウンス処理を実装
- 環境変数 NUXT_PUBLIC_GA_ID で測定IDを設定可能
- 開発環境では GA ID 未設定時にコンソール出力
- SiteInfoModal にアクセス解析についての説明を追加
- 主な機能セクションにプレイリスト機能などを追加
- GA4セットアップガイドと実装概要ドキュメントを追加