### PR TITLE
feat: Font Awesome Pro Duotone を導入し絵文字を置き換え

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}

--- a/app/components/LatestSongVideo.vue
+++ b/app/components/LatestSongVideo.vue
@@ -1,7 +1,9 @@
 <template>
   <section class="bg-white rounded-lg shadow-md overflow-hidden">
     <div class="bg-gradient-to-r from-slate-600 to-slate-700 text-white p-4">
-      <h2 class="text-xl font-bold flex items-center">🎤 最新の歌ってみた</h2>
+      <h2 class="text-xl font-bold flex items-center gap-2">
+        <FontAwesomeIcon :icon="['fad', 'microphone']" class="w-5 h-5" />最新の歌ってみた
+      </h2>
     </div>
 
     <div v-if="video" class="p-4">

--- a/app/components/LatestStreamVideo.vue
+++ b/app/components/LatestStreamVideo.vue
@@ -1,7 +1,9 @@
 <template>
   <section class="bg-white rounded-lg shadow-md overflow-hidden">
     <div class="bg-gradient-to-r from-slate-500 to-slate-600 text-white p-4">
-      <h2 class="text-xl font-bold flex items-center">📺 最新の歌配信</h2>
+      <h2 class="text-xl font-bold flex items-center gap-2">
+        <FontAwesomeIcon :icon="['fad', 'tv']" class="w-5 h-5" />最新の歌配信
+      </h2>
     </div>
 
     <div v-if="video" class="p-4">

--- a/app/components/SiteInfoModal.vue
+++ b/app/components/SiteInfoModal.vue
@@ -63,7 +63,7 @@
             <h3
               class="text-lg font-semibold text-white mb-3 flex items-center gap-2"
             >
-              <span>🎵</span>
+              <FontAwesomeIcon :icon="['fad', 'music-note']" class="w-4 h-4" />
               <span>いぬいのうたについて</span>
             </h3>
             <div class="text-sm leading-relaxed space-y-3">
@@ -91,7 +91,7 @@
             <h3
               class="text-lg font-semibold text-white mb-3 flex items-center gap-2"
             >
-              <span>✨</span>
+              <FontAwesomeIcon :icon="['fad', 'sparkles']" class="w-4 h-4" />
               <span>主な機能</span>
             </h3>
             <ul class="text-sm space-y-2 list-disc list-inside">
@@ -108,7 +108,7 @@
             <h3
               class="text-lg font-semibold text-white mb-3 flex items-center gap-2"
             >
-              <span>⚙️</span>
+              <FontAwesomeIcon :icon="['fad', 'gear']" class="w-4 h-4" />
               <span>技術スタック</span>
             </h3>
             <div class="text-sm space-y-2">
@@ -134,7 +134,7 @@
             <h3
               class="text-lg font-semibold text-white mb-3 flex items-center gap-2"
             >
-              <span>🔗</span>
+              <FontAwesomeIcon :icon="['fad', 'link']" class="w-4 h-4" />
               <span>関連リンク</span>
             </h3>
             <div class="space-y-2 text-sm">
@@ -144,7 +144,7 @@
                 rel="noopener noreferrer"
                 class="flex items-center gap-2 text-blue-400 hover:text-blue-300 transition-colors"
               >
-                <span>📺</span>
+                <FontAwesomeIcon :icon="['fab', 'youtube']" class="w-4 h-4" />
                 <span>戌亥とこ YouTubeチャンネル</span>
               </a>
               <a
@@ -153,7 +153,7 @@
                 rel="noopener noreferrer"
                 class="flex items-center gap-2 text-blue-400 hover:text-blue-300 transition-colors"
               >
-                <span>🐦</span>
+                <FontAwesomeIcon :icon="['fab', 'x-twitter']" class="w-4 h-4" />
                 <span>戌亥とこ Twitter</span>
               </a>
             </div>
@@ -164,7 +164,7 @@
             <h3
               class="text-lg font-semibold text-white mb-3 flex items-center gap-2"
             >
-              <span>📧</span>
+              <FontAwesomeIcon :icon="['fad', 'envelope']" class="w-4 h-4" />
               <span>連絡先</span>
             </h3>
             <div class="space-y-2 text-sm">
@@ -209,7 +209,7 @@
             <h3
               class="text-lg font-semibold text-white mb-3 flex items-center gap-2"
             >
-              <span>📊</span>
+              <FontAwesomeIcon :icon="['fad', 'chart-bar']" class="w-4 h-4" />
               <span>アクセス解析について</span>
             </h3>
             <div class="text-sm leading-relaxed space-y-3">

--- a/app/components/SongRow.vue
+++ b/app/components/SongRow.vue
@@ -18,7 +18,7 @@
               @error="handleImageError"
             />
             <span v-else :class="SONG_ROW_STYLES.thumbnail.placeholder"
-              >🎵</span
+              ><FontAwesomeIcon :icon="['fad', 'music-note']" /></span
             >
           </div>
           <!-- 再生状態インジケーター -->
@@ -116,7 +116,7 @@
             loading="lazy"
             @error="handleImageError"
           />
-          <span v-else :class="SONG_ROW_STYLES.thumbnail.placeholder">🎵</span>
+          <span v-else :class="SONG_ROW_STYLES.thumbnail.placeholder"><FontAwesomeIcon :icon="['fad', 'music-note']" /></span>
         </div>
         <!-- 再生状態インジケーター -->
         <div

--- a/app/components/StreamRow.vue
+++ b/app/components/StreamRow.vue
@@ -21,7 +21,7 @@
                 loading="lazy"
                 @error="handleImageError"
               />
-              <span v-else class="text-sm text-gray-400">🎤</span>
+              <span v-else class="text-sm text-gray-400"><FontAwesomeIcon :icon="['fad', 'microphone']" /></span>
             </div>
           </div>
 
@@ -67,7 +67,7 @@
                 非公開
               </span>
               <span v-if="stream.unplayable" class="text-xs text-red-500">
-                ⚠️ 再生不可
+                <FontAwesomeIcon :icon="['fad', 'triangle-exclamation']" class="mr-0.5" />再生不可
               </span>
             </div>
             <!-- 日時情報（モバイル） -->
@@ -143,7 +143,7 @@
                 loading="lazy"
                 @error="handleImageError"
               />
-              <span v-else class="text-gray-400">🎤</span>
+              <span v-else class="text-gray-400"><FontAwesomeIcon :icon="['fad', 'microphone']" /></span>
             </div>
           </div>
 
@@ -193,7 +193,7 @@
                     非公開
                   </span>
                   <span v-if="stream.unplayable" class="text-sm text-red-500">
-                    ⚠️ 再生不可
+                    <FontAwesomeIcon :icon="['fad', 'triangle-exclamation']" class="mr-0.5" />再生不可
                   </span>
                 </div>
 

--- a/app/components/layout/Header.vue
+++ b/app/components/layout/Header.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { ref } from "vue";
+  import type { IconProp } from "@fortawesome/fontawesome-svg-core";
 
   const isMenuOpen = ref(false);
   const isSiteInfoModalOpen = ref(false);
@@ -21,12 +22,12 @@
   };
 
   // ナビゲーションアイテム
-  const navItems = [
-    { to: "/", label: "ホーム", icon: "🏠" },
-    { to: "/songs", label: "楽曲一覧", icon: "🎶" },
-    { to: "/streams", label: "歌枠一覧", icon: "📺" },
-    { to: "/playlists", label: "プレイリスト", icon: "📝" },
-    { to: "/timeline", label: "タイムライン", icon: "📅" },
+  const navItems: Array<{ to: string; label: string; icon: IconProp }> = [
+    { to: "/", label: "ホーム", icon: ["fad", "house"] },
+    { to: "/songs", label: "楽曲一覧", icon: ["fad", "music-note"] },
+    { to: "/streams", label: "歌枠一覧", icon: ["fad", "tv"] },
+    { to: "/playlists", label: "プレイリスト", icon: ["fad", "list-music"] },
+    { to: "/timeline", label: "タイムライン", icon: ["fad", "list-timeline"] },
   ];
 </script>
 
@@ -54,7 +55,7 @@
                 class="flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors hover:bg-gray-700 hover:text-white"
                 :class="{ 'bg-gray-700 text-white': $route.path === item.to }"
               >
-                <span class="text-base">{{ item.icon }}</span>
+                <FontAwesomeIcon :icon="item.icon" class="w-4 h-4" />
                 {{ item.label }}
               </NuxtLink>
             </li>
@@ -163,7 +164,7 @@
                 :class="{ 'bg-gray-700 text-white': $route.path === item.to }"
                 @click="closeMenu"
               >
-                <span class="text-base">{{ item.icon }}</span>
+                <FontAwesomeIcon :icon="item.icon" class="w-4 h-4" />
                 {{ item.label }}
               </NuxtLink>
             </li>
@@ -173,7 +174,10 @@
                 class="flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors hover:bg-gray-700 w-full text-left"
                 @click="openSiteInfoModal"
               >
-                <span class="text-base">ℹ️</span>
+                <FontAwesomeIcon
+                  :icon="['fad', 'circle-info']"
+                  class="w-4 h-4"
+                />
                 サイト情報
               </button>
             </li>

--- a/app/components/layout/Sidebar.vue
+++ b/app/components/layout/Sidebar.vue
@@ -64,7 +64,7 @@
                 to="/"
                 class="flex items-center gap-2 hover:bg-gray-600 rounded px-2 py-1 transition-colors"
               >
-                <span aria-hidden="true">🏠</span> ホーム
+                <FontAwesomeIcon :icon="['fad', 'house']" class="w-4 h-4" aria-hidden="true" /> ホーム
               </NuxtLink>
             </li>
             <li>
@@ -72,7 +72,7 @@
                 to="/songs"
                 class="flex items-center gap-2 hover:bg-gray-600 rounded px-2 py-1 transition-colors"
               >
-                <span aria-hidden="true">🎶</span> 楽曲一覧
+                <FontAwesomeIcon :icon="['fad', 'music-note']" class="w-4 h-4" aria-hidden="true" /> 楽曲一覧
               </NuxtLink>
             </li>
             <li>
@@ -80,7 +80,7 @@
                 to="/streams"
                 class="flex items-center gap-2 hover:bg-gray-600 rounded px-2 py-1 transition-colors"
               >
-                <span aria-hidden="true">🎤</span> 歌枠一覧
+                <FontAwesomeIcon :icon="['fad', 'microphone']" class="w-4 h-4" aria-hidden="true" /> 歌枠一覧
               </NuxtLink>
             </li>
             <li>
@@ -88,7 +88,7 @@
                 to="/timeline"
                 class="flex items-center gap-2 hover:bg-gray-600 rounded px-2 py-1 transition-colors"
               >
-                <span aria-hidden="true">📅</span> タイムライン
+                <FontAwesomeIcon :icon="['fad', 'calendar-days']" class="w-4 h-4" aria-hidden="true" /> タイムライン
               </NuxtLink>
             </li>
             <li>
@@ -96,7 +96,7 @@
                 to="/playlists"
                 class="flex items-center gap-2 hover:bg-gray-600 rounded px-2 py-1 transition-colors"
               >
-                <span aria-hidden="true">🎵</span> プレイリスト
+                <FontAwesomeIcon :icon="['fad', 'list-music']" class="w-4 h-4" aria-hidden="true" /> プレイリスト
               </NuxtLink>
             </li>
           </ul>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -151,7 +151,7 @@
     <!-- ナビゲーションセクション -->
     <section class="bg-white rounded-lg shadow-md p-6">
       <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">
-        🎵 コンテンツを探す
+        <FontAwesomeIcon :icon="['fad', 'music-note']" class="mr-2" />コンテンツを探す
       </h2>
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -160,7 +160,9 @@
           class="group bg-gradient-to-br from-slate-600 to-slate-700 text-white p-6 rounded-lg hover:from-slate-700 hover:to-slate-800 transition-all transform hover:scale-105"
         >
           <div class="text-center space-y-2">
-            <div class="text-3xl">🎤</div>
+            <div class="text-3xl">
+              <FontAwesomeIcon :icon="['fad', 'microphone']" />
+            </div>
             <h3 class="font-bold text-lg">楽曲一覧</h3>
             <p class="text-sm opacity-90">すべての楽曲を検索・再生</p>
           </div>
@@ -171,7 +173,9 @@
           class="group bg-gradient-to-br from-slate-500 to-slate-600 text-white p-6 rounded-lg hover:from-slate-600 hover:to-slate-700 transition-all transform hover:scale-105"
         >
           <div class="text-center space-y-2">
-            <div class="text-3xl">📺</div>
+            <div class="text-3xl">
+              <FontAwesomeIcon :icon="['fad', 'tv']" />
+            </div>
             <h3 class="font-bold text-lg">配信一覧</h3>
             <p class="text-sm opacity-90">歌配信・動画アーカイブ</p>
           </div>
@@ -182,7 +186,9 @@
           class="group bg-gradient-to-br from-slate-400 to-slate-500 text-white p-6 rounded-lg hover:from-slate-500 hover:to-slate-600 transition-all transform hover:scale-105"
         >
           <div class="text-center space-y-2">
-            <div class="text-3xl">📝</div>
+            <div class="text-3xl">
+              <FontAwesomeIcon :icon="['fad', 'list-music']" />
+            </div>
             <h3 class="font-bold text-lg">プレイリスト</h3>
             <p class="text-sm opacity-90">お気に入りの楽曲をまとめて</p>
           </div>

--- a/app/pages/songs/[id].vue
+++ b/app/pages/songs/[id].vue
@@ -71,7 +71,7 @@
                 v-else
                 class="w-full h-full flex items-center justify-center text-gray-400 text-6xl"
               >
-                🎵
+                <FontAwesomeIcon :icon="['fad', 'music-note']" />
               </div>
             </div>
           </div>

--- a/app/pages/streams/index.vue
+++ b/app/pages/streams/index.vue
@@ -34,7 +34,7 @@
             title="ランダムな歌枠の楽曲をキューに設定"
             @click="fetchRandomStream"
           >
-            🎲 ランダムキュー
+            <FontAwesomeIcon :icon="['fad', 'shuffle']" class="mr-1" /> ランダムキュー
           </button>
         </div>
       </div>
@@ -74,7 +74,9 @@
 
     <!-- 結果が見つからない場合 -->
     <div v-else class="text-center py-8">
-      <div class="text-gray-400 text-6xl mb-4">🎤</div>
+      <div class="text-gray-400 text-6xl mb-4">
+        <FontAwesomeIcon :icon="['fad', 'microphone']" />
+      </div>
       <h3 class="text-xl font-semibold text-gray-700 mb-2">
         歌枠が見つかりませんでした
       </h3>

--- a/app/pages/timeline.vue
+++ b/app/pages/timeline.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import type { Video } from "~/types/video";
+  import type { IconProp } from "@fortawesome/fontawesome-svg-core";
 
   useSeoMeta({
     title: "タイムライン | いぬいのうた",
@@ -234,7 +235,12 @@
   <div class="container mx-auto px-4 py-8 pb-32">
     <!-- ページヘッダー -->
     <div class="mb-8">
-      <h1 class="text-3xl font-bold text-gray-900 mb-2">📅 タイムライン</h1>
+      <h1 class="text-3xl font-bold text-gray-900 mb-2">
+        <FontAwesomeIcon
+          :icon="['fad', 'list-timeline']"
+          class="mr-2"
+        />タイムライン
+      </h1>
       <p class="text-gray-600">
         全{{ filteredVideos.length }}件の動画を時系列で表示
       </p>
@@ -245,9 +251,21 @@
         <div class="flex gap-2">
           <button
             v-for="f in [
-              { key: 'all' as VideoFilter, label: 'すべて', icon: '🎬' },
-              { key: 'song' as VideoFilter, label: '歌動画', icon: '🎵' },
-              { key: 'stream' as VideoFilter, label: '歌枠', icon: '🎤' },
+              {
+                key: 'all' as VideoFilter,
+                label: 'すべて',
+                icon: ['fad', 'film'] as IconProp,
+              },
+              {
+                key: 'song' as VideoFilter,
+                label: '歌動画',
+                icon: ['fad', 'music-note'] as IconProp,
+              },
+              {
+                key: 'stream' as VideoFilter,
+                label: '歌枠',
+                icon: ['fad', 'microphone'] as IconProp,
+              },
             ]"
             :key="f.key"
             class="px-4 py-2 rounded-md text-sm font-medium transition-colors"
@@ -258,7 +276,7 @@
             "
             @click="activeFilter = f.key"
           >
-            {{ f.icon }} {{ f.label }}
+            <FontAwesomeIcon :icon="f.icon" class="mr-1" /> {{ f.label }}
           </button>
         </div>
 
@@ -397,7 +415,11 @@
                       <span
                         class="inline-block px-1.5 py-0.5 rounded text-[10px] font-bold bg-black/70 text-white"
                       >
-                        🎵 {{ video.songs_count }}
+                        <FontAwesomeIcon
+                          :icon="['fad', 'music-note']"
+                          class="mr-0.5"
+                        />
+                        {{ video.songs_count }}
                       </span>
                     </div>
 
@@ -445,7 +467,9 @@
 
     <!-- データなし -->
     <div v-else class="text-center py-16">
-      <div class="text-gray-400 text-6xl mb-4">📅</div>
+      <div class="text-gray-400 text-6xl mb-4">
+        <FontAwesomeIcon :icon="['fad', 'calendar-days']" />
+      </div>
       <h3 class="text-xl font-semibold text-gray-700 mb-2">
         該当する動画がありません
       </h3>

--- a/app/plugins/fontawesome.ts
+++ b/app/plugins/fontawesome.ts
@@ -1,0 +1,56 @@
+import { library, config } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+// CSS の二重読み込みを防ぐ（nuxt.config.ts の css[] で管理する）
+config.autoAddCss = false;
+
+// ---- Duotone アイコン登録 ----
+// 使用するアイコンをここに追加していく。全量 import は避けバンドルサイズを削減する。
+import {
+  faHouse,
+  faMusicNote,
+  faMicrophone,
+  faTv,
+  faCalendarDays,
+  faListMusic,
+  faCircleInfo,
+  faListTimeline,
+  faFilm,
+  faShuffle,
+  faTriangleExclamation,
+  faSparkles,
+  faGear,
+  faLink,
+  faEnvelope,
+  faChartBar,
+} from "@fortawesome/pro-duotone-svg-icons";
+
+// ---- Brands アイコン登録 ----
+import { faYoutube, faXTwitter } from "@fortawesome/free-brands-svg-icons";
+
+library.add(
+  // Duotone
+  faHouse,
+  faMusicNote,
+  faMicrophone,
+  faTv,
+  faCalendarDays,
+  faListMusic,
+  faCircleInfo,
+  faListTimeline,
+  faFilm,
+  faShuffle,
+  faTriangleExclamation,
+  faSparkles,
+  faGear,
+  faLink,
+  faEnvelope,
+  faChartBar,
+  // Brands
+  faYoutube,
+  faXTwitter,
+);
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.component("FontAwesomeIcon", FontAwesomeIcon);
+});

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,7 +5,18 @@ export default defineNuxtConfig({
   compatibilityDate: "2024-11-01",
   devtools: { enabled: true },
 
-  css: ["~/assets/css/main.css"],
+  css: [
+    "~/assets/css/main.css",
+    "@fortawesome/fontawesome-svg-core/styles.css",
+  ],
+  build: {
+    transpile: [
+      "@fortawesome/fontawesome-svg-core",
+      "@fortawesome/vue-fontawesome",
+      "@fortawesome/pro-duotone-svg-icons",
+      "@fortawesome/free-brands-svg-icons",
+    ],
+  },
   modules: ["@nuxt/eslint", "@pinia/nuxt", "nuxt-gtag"],
   gtag: {
     id: process.env.NUXT_PUBLIC_GA_ID || "",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.2.0",
+    "@fortawesome/free-brands-svg-icons": "^7.2.0",
+    "@fortawesome/pro-duotone-svg-icons": "^7.2.0",
+    "@fortawesome/vue-fontawesome": "^3.0.0",
     "@nuxt/eslint": "1.2.0",
     "@pinia/nuxt": "^0.11.0",
     "@tailwindcss/vite": "^4.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@fortawesome/fontawesome-svg-core':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@fortawesome/free-brands-svg-icons':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@fortawesome/pro-duotone-svg-icons':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@fortawesome/vue-fontawesome':
+        specifier: ^3.0.0
+        version: 3.1.3(@fortawesome/fontawesome-svg-core@7.2.0)(vue@3.5.22(typescript@5.9.3))
       '@nuxt/eslint':
         specifier: 1.2.0
         version: 1.2.0(@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.22)(eslint@9.38.0(jiti@2.6.1))(magicast@0.5.1)(typescript@5.9.3)(vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1))
@@ -430,6 +442,28 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fortawesome/fontawesome-common-types@7.2.0':
+    resolution: {integrity: sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    resolution: {integrity: sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/free-brands-svg-icons@7.2.0':
+    resolution: {integrity: sha512-VNG8xqOip1JuJcC3zsVsKRQ60oXG9+oYNDCosjoU/H9pgYmLTEwWw8pE0jhPz/JWdHeUuK6+NQ3qsM4gIbdbYQ==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/pro-duotone-svg-icons@7.2.0':
+    resolution: {integrity: sha512-G0oZPLWrOjodNsKEzjnmZ/wzXCQhyXHsscIuCsRwPr42N0zgMmVvClZuEq6eqiBiyo1qhm3RnN6xNLddJh9z7A==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/vue-fontawesome@3.1.3':
+    resolution: {integrity: sha512-OHHUTLPEzdwP8kcYIzhioUdUOjZ4zzmi+midwa4bqscza4OJCOvTKJEHkXNz8PgZ23kWci1HkKVX0bm8f9t9gQ==}
+    peerDependencies:
+      '@fortawesome/fontawesome-svg-core': ~1 || ~6 || ~7
+      vue: '>= 3.0.0 < 4'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4616,6 +4650,25 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@fortawesome/fontawesome-common-types@7.2.0': {}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/free-brands-svg-icons@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/pro-duotone-svg-icons@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/vue-fontawesome@3.1.3(@fortawesome/fontawesome-svg-core@7.2.0)(vue@3.5.22(typescript@5.9.3))':
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 7.2.0
+      vue: 3.5.22(typescript@5.9.3)
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
- @fortawesome/fontawesome-svg-core, vue-fontawesome, pro-duotone-svg-icons をインストール
- @fortawesome/free-brands-svg-icons をインストール（YouTube/X-Twitter アイコン）
- .npmrc を追加（env var 参照によるレジストリ認証）
- app/plugins/fontawesome.ts を追加（アイコン library 登録・グローバルコンポーネント登録）
- nuxt.config.ts に FA CSS と build.transpile を追加
- Header.vue, Sidebar.vue: ナビゲーションアイコンを FontAwesomeIcon に移行
- index.vue: コンテンツ探すセクションのアイコンを移行
- timeline.vue: ページ見出し・フィルター・楽曲数バッジ・空状態を移行
- streams/index.vue: ランダムキューボタン・空状態を移行
- songs/[id].vue: サムネイルプレースホルダーを移行
- LatestSongVideo.vue, LatestStreamVideo.vue: セクション見出しを移行
- SongRow.vue: サムネイルプレースホルダーを移行
- StreamRow.vue: サムネイルプレースホルダー・再生不可バッジを移行
- SiteInfoModal.vue: 各セクション見出し・リンクアイコンを移行